### PR TITLE
Move test hook constructor into Private module

### DIFF
--- a/src/index.ml
+++ b/src/index.ml
@@ -2,6 +2,12 @@ module Private = struct
   module Fan = Fan
   module Io_array = Io_array
   module Search = Search
+
+  module Hook = struct
+    type 'a t = 'a -> unit
+
+    let v f = f
+  end
 end
 
 module type Key = sig
@@ -59,8 +65,7 @@ module type S = sig
 
   val iter : (key -> value -> unit) -> t -> unit
 
-  val force_merge :
-    ?hook:[> `After of unit -> unit | `Before of unit -> unit ] -> t -> unit
+  val force_merge : ?hook:[ `After | `Before ] Private.Hook.t -> t -> unit
 
   val flush : t -> unit
 
@@ -530,7 +535,7 @@ module Make (K : Key) (V : Value) (IO : IO) = struct
     t.log_async <- Some log_async;
 
     let go () =
-      (match hook with Some (`Before f) -> f () | _ -> ());
+      may (fun f -> f `Before) hook;
       let log = assert_and_get t.log in
       let generation = Int64.succ t.generation in
       let log_array =
@@ -590,7 +595,7 @@ module Make (K : Key) (V : Value) (IO : IO) = struct
             log_async.mem;
           IO.sync log.io;
           t.log_async <- None);
-      (match hook with Some (`After f) -> f () | _ -> ());
+      may (fun f -> f `After) hook;
       IO.clear log_async.io;
       IO.close log_async.io;
       IO.Mutex.unlock t.merge_lock

--- a/src/index.mli
+++ b/src/index.mli
@@ -49,6 +49,22 @@ module type Key = sig
   (** Formatter for keys *)
 end
 
+(** These modules should not be used. They are exposed purely for testing
+    purposes. *)
+module Private : sig
+  module Search : module type of Search
+
+  module Io_array : module type of Io_array
+
+  module Fan : module type of Fan
+
+  module Hook : sig
+    type 'a t
+
+    val v : ('a -> unit) -> 'a t
+  end
+end
+
 (** The input of [Make] for values. The same requirements as for [Key] apply. *)
 module type Value = sig
   type t
@@ -114,8 +130,7 @@ module type S = sig
       recent replacements of existing values (after the last merge), this will
       hit both the new and old bindings. *)
 
-  val force_merge :
-    ?hook:[> `After of unit -> unit | `Before of unit -> unit ] -> t -> unit
+  val force_merge : ?hook:[ `After | `Before ] Private.Hook.t -> t -> unit
   (** [force_merge t] forces a merge for [t]. *)
 
   val flush : t -> unit
@@ -127,13 +142,3 @@ end
 
 module Make (K : Key) (V : Value) (IO : IO) :
   S with type key = K.t and type value = V.t
-
-(** These modules should not be used. They are exposed purely for testing
-    purposes. *)
-module Private : sig
-  module Search : module type of Search
-
-  module Io_array : module type of Io_array
-
-  module Fan : module type of Fan
-end


### PR DESCRIPTION
- makes the type of the test hooks abstract, requiring use of a constructor inside `Private.Hook`
- slightly alters the hook type to allow hooking into multiple stages in a single merge (not currently being exploited by the tests, but potentially eventually useful)