### PR TITLE
Improve test coverage for filter

### DIFF
--- a/test/unix/main.ml
+++ b/test/unix/main.ml
@@ -16,6 +16,14 @@ let rec random_new_key tbl =
   let r = Key.v () in
   if Hashtbl.mem tbl r then random_new_key tbl else r
 
+let random_existing_key tbl =
+  (* The only way to get a random key out of a Hashtbl before
+     4.07.0 is to iterate over all the keys (though tbl is usually small). *)
+  let pick_first k _ = function None -> Some k | p -> p in
+  match Hashtbl.fold pick_first tbl None with
+  | None -> Alcotest.fail "Provided table contains no keys."
+  | Some k -> k
+
 let check_entry findf k v =
   match findf k with
   | v' when v = v' -> ()
@@ -366,15 +374,65 @@ module Filter = struct
   let filter_none () =
     let Context.{ rw; tbl; _ } = Context.full_index () in
     Index.filter rw (fun _ -> true);
-    check_equivalence rw tbl
+    check_equivalence rw tbl;
+    Index.close rw
 
   let filter_all () =
     let Context.{ rw; _ } = Context.full_index () in
     Index.filter rw (fun _ -> false);
-    check_equivalence rw (Hashtbl.create 0)
+    check_equivalence rw (Hashtbl.create 0);
+    Index.close rw
+
+  let filter_one () =
+    let Context.{ rw; tbl; _ } = Context.full_index () in
+    let k = random_existing_key tbl in
+    Hashtbl.remove tbl k;
+    Index.filter rw (fun (k', _) -> k <> k');
+    check_equivalence rw tbl;
+    Index.close rw
+
+  let clone_then_filter () =
+    let Context.{ rw; tbl; clone } = Context.full_index () in
+    let k = random_existing_key tbl in
+    Hashtbl.remove tbl k;
+    let rw2 = clone ~readonly:false () in
+    Index.filter rw (fun (k', _) -> k <> k');
+    check_equivalence rw tbl;
+    check_equivalence rw2 tbl;
+    Index.close rw;
+    Index.close rw2
+
+  let filter_then_clone () =
+    let Context.{ rw; tbl; clone } = Context.full_index () in
+    let k = random_existing_key tbl in
+    Hashtbl.remove tbl k;
+    Index.filter rw (fun (k', _) -> k <> k');
+    let rw2 = clone ~readonly:false () in
+    check_equivalence rw tbl;
+    check_equivalence rw2 tbl;
+    Index.close rw;
+    Index.close rw2
+
+  let empty_after_filter_then_fresh () =
+    let Context.{ rw; tbl; clone } = Context.full_index () in
+    let k = random_existing_key tbl in
+    Hashtbl.remove tbl k;
+    Index.filter rw (fun (k', _) -> k <> k');
+    let rw2 = clone ~fresh:true ~readonly:false () in
+    (* rw2 should be empty since it is fresh. *)
+    check_equivalence rw2 (Hashtbl.create 0);
+    Index.close rw;
+    Index.close rw2
 
   let tests =
-    [ ("filter none", `Quick, filter_none); ("filter all", `Quick, filter_all) ]
+    [
+      ("filter none", `Quick, filter_none);
+      ("filter all", `Quick, filter_all);
+      ("filter one", `Quick, filter_one);
+      ("clone then filter", `Quick, clone_then_filter);
+      ("filter then clone", `Quick, filter_then_clone);
+      ("empty after filter+fresh", `Quick, empty_after_filter_then_fresh);
+    ]
 end
 
 let () =


### PR DESCRIPTION
- Fixes the `filter_none` and `filter_all` tests by closing the `Index` after use.
- Adds a `random_existing_key : ('a, 'b) Hashtbl.t -> 'a` utility function.
- Adds tests to check what happens:
    - when a single element is filtered out of the index;
    - when the index is cloned before or after filtering;
    - when a fresh index is created after filtering on the previous one.